### PR TITLE
feat: override state(former "enviroment") values via command-line args

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,10 @@ USAGE:
    helmfile [global options] command [command options] [arguments...]
 
 VERSION:
-   v0.52.0
+   v0.70.0
 
 COMMANDS:
+     deps      update charts based on the contents of requirements.yaml
      repos     sync repositories from state file (helm repo add && helm repo update)
      charts    DEPRECATED: sync releases from state file (helm upgrade --install)
      diff      diff releases from state file against env (helm diff)
@@ -339,6 +340,8 @@ GLOBAL OPTIONS:
    --helm-binary value, -b value           path to helm binary
    --file helmfile.yaml, -f helmfile.yaml  load config from file or directory. defaults to helmfile.yaml or `helmfile.d`(means `helmfile.d/*.yaml`) in this preference
    --environment default, -e default       specify the environment name. defaults to default
+   --state-values-set value                set state values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+   --state-values-file value               specify state values in a YAML file
    --quiet, -q                             Silence output. Equivalent to log-level warn
    --kube-context value                    Set kubectl context. Uses current context by default
    --log-level value                       Set log level, default info
@@ -347,6 +350,7 @@ GLOBAL OPTIONS:
                                            A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
                                            --selector tier=frontend,tier!=proxy --selector tier=backend. Will match all frontend, non-proxy releases AND all backend releases.
                                            The name of a release can be used as a label. --selector name=myrelease
+   --allow-no-matching-release             Do not exit with an error code if the provided selector has no matching releases.
    --interactive, -i                       Request confirmation before attempting to modify clusters
    --help, -h                              show help
    --version, -v                           print the version

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -10,6 +10,8 @@ type ConfigProvider interface {
 	KubeContext() string
 	Namespace() string
 	Selectors() []string
+	Set() map[string]interface{}
+	ValuesFiles() []string
 	Env() string
 
 	loggingConfig

--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -27,12 +27,6 @@ type desiredStateLoader struct {
 	logger *zap.SugaredLogger
 }
 
-type LoadOpts struct {
-	Selectors   []string
-	Environment state.SubhelmfileEnvironmentSpec
-	CalleePath  string
-}
-
 func (ld *desiredStateLoader) Load(f string, opts LoadOpts) (*state.HelmState, error) {
 	var overrodeEnv *environment.Environment
 

--- a/pkg/app/load_opts.go
+++ b/pkg/app/load_opts.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"github.com/roboll/helmfile/pkg/state"
+	"gopkg.in/yaml.v2"
+)
+
+type LoadOpts struct {
+	Selectors   []string
+	Environment state.SubhelmfileEnvironmentSpec
+
+	// CalleePath is the absolute path to the file being loaded
+	CalleePath string
+}
+
+func (o LoadOpts) DeepCopy() LoadOpts {
+	bytes, err := yaml.Marshal(o)
+	if err != nil {
+		panic(err)
+	}
+
+	new := LoadOpts{}
+	if err := yaml.Unmarshal(bytes, &new); err != nil {
+		panic(err)
+	}
+
+	return new
+}

--- a/pkg/maputil/maputil.go
+++ b/pkg/maputil/maputil.go
@@ -48,3 +48,28 @@ func CastKeysToStrings(s interface{}) (map[string]interface{}, error) {
 	}
 	return new, nil
 }
+
+func Set(m map[string]interface{}, key []string, value string) map[string]interface{} {
+	if len(key) == 0 {
+		panic(fmt.Errorf("bug: unexpected length of key: %d", len(key)))
+	}
+
+	k := key[0]
+
+	if len(key) == 1 {
+		m[k] = value
+		return m
+	}
+
+	remain := key[1:]
+
+	nested, ok := m[k]
+	if !ok {
+		new_m := map[string]interface{}{}
+		nested = Set(new_m, remain, value)
+	}
+
+	m[k] = nested
+
+	return m
+}


### PR DESCRIPTION
The addition of `--set k1=v1,k2=v2` and `--values file1 --values file2` was originally planned in #361.

But it turned out we already had `--values` for existing helmfile commands like `sync`. Duplicated flags doesn't work, obviously.

So this actually add `--state-values-set k1=v1,k2=v2` and `--set-values-file file1 --set-values-file file2`.

They are called "state" values according to the discussion we had at #640

Resolves #361